### PR TITLE
chore(deps): consolidate dependency updates for v0.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "dtt"
-version = "0.0.10"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300fa4cbe63b08446f74755c6cc002fb70e45bf50c32390f475d19b1ef23bc8e"
+checksum = "d3ad961df245c82bc67098f5bd69640d3194a081df8f0f5df1f017db4a05292a"
 dependencies = [
  "pastey",
  "serde",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "frontmatter-gen"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "noyalib"
-version = "0.0.8"
+version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14057395c16a4230575c6f86bfa074db87e8458626d3e56b20c2454334a7e50c"
+checksum = "179fb3ecf8e64246b67049033e61c739c467c7bb1d79b2c1a65c1ac13f87512a"
 dependencies = [
  "indexmap",
  "memchr",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "frontmatter-gen"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 rust-version = "1.85.0"
 license = "MIT OR Apache-2.0"
@@ -91,7 +91,7 @@ ssg = [                                 # Full SSG functionality
 anyhow = "1.0.95"
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
-noyalib = { version = "0.0.8", default-features = false, features = ["std"] }
+noyalib = { version = "0.0.17", default-features = false, features = ["std"] }
 time = { version = "0.3.36", features = ["formatting", "local-offset"] }
 tokio = { version = "1.44", features = ["full"] }
 
@@ -104,7 +104,7 @@ log = "0.4.22"
 
 # Optional CLI and SSG dependencies - all must have optional = true
 clap = { version = "4.5.21", features = ["derive"], optional = true }
-dtt = { version = "0.0.10", optional = true }
+dtt = { version = "0.0.11", optional = true }
 pulldown-cmark = { version = "0.13.4", optional = true }
 simple_logger = "5.0.0"
 tempfile = "3.14.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,11 +374,13 @@ mod tests {
             let err = cli.unwrap_err();
             let output = err.to_string();
 
-            // Assert that the output contains the correct version
+            // Assert that the output contains the correct version.
+            // Read it from the manifest so this cannot go stale on a
+            // version bump.
+            let expected = env!("CARGO_PKG_VERSION");
             assert!(
-                output.contains("0.0.6"),
-                "Version output does not contain '0.0.6'. Actual output: {}",
-                output
+                output.contains(expected),
+                "Version output does not contain '{expected}'. Actual output: {output}"
             );
         }
     }


### PR DESCRIPTION
Consolidates the open Dependabot PRs into a single release branch and bumps the version to `0.0.8`.

### Superseded updates

| PR | Update |
|----|--------|
| #28 | chore(deps): bump dtt from 0.0.10 to 0.0.11 |
| #27 | chore(deps): bump noyalib from 0.0.8 to 0.0.17 |
| #26 | chore(deps): bump toml from 1.1.3+spec-1.1.0 to 1.1.4+spec-1.1.0 in the minor-and-patch group |

### Verification

- `cargo fmt --all --check` clean ✅
- `cargo clippy --all-features --all-targets -- -D warnings` clean ✅
- `cargo test --all-features` — 286 tests pass, 0 failures ✅

### Notes

**`tera` (#29) is deliberately not in this branch.** #25 (`feat/v0.0.8`) already migrates tera 1.20 → 2.1 together with the `src/engine.rs` changes the new API requires; taking the version bump on its own would not compile. #29 has been closed pointing at #25.

**Version held at 0.0.8** to match the live `feat/v0.0.8` branch rather than bumping past it.

**Pre-existing test fix.** `tests::test_version_output` in `src/main.rs` asserted a hardcoded `"0.0.6"` while the manifest was already at 0.0.7, so it failed on `main` before this branch. It now reads `env!("CARGO_PKG_VERSION")` so it cannot go stale on a future bump.
